### PR TITLE
bug: unit_ses and variables arguments

### DIFF
--- a/R/build_margins.R
+++ b/R/build_margins.R
@@ -41,9 +41,13 @@ function(model,
         vmat <- do.call("rbind", lapply(seq_len(nrow(data)), function(datarow) {
             delta_once(data = data[datarow,], model = model, type = type, vcov = vcov, eps = eps, ...)
         }))
-        colnames(vmat) <- paste0("SE_", names(mes))
         vmat <- as.data.frame(vmat)
         vmat[] <- lapply(vmat, sqrt)
+
+        # When variables != NULL, vmat and mes need to be aligned
+        vmat <- vmat[, colnames(mes), drop = FALSE] # keep as data.frame even if only one column is selected
+
+        colnames(vmat) <- paste0("SE_", colnames(vmat))
     }
     
     # obtain predicted values and standard errors


### PR DESCRIPTION
The `variables` argument does not work in conjunction with the `unit_ses = TRUE` argument.

```
library(margins)
N = 100 
dat = data.frame('x' = rnorm(N),
                 'y' = rnorm(N),
                 'z' = sample(letters[1:5], N, replace = TRUE))
mod = lm(y ~ x + z, dat)
margins::margins(mod, unit_ses = TRUE, variables = 'x')
```

This is a temporary fix, that just aligns the standard errors and marginal effects data frames. The package still calculates all unit-specific SEs, so specifying a subset of variables yields (almost) no time savings when `unit_ses = TRUE`.

I don't understand the package well enough to know if it's possible to only calculate `unit_ses` for a subset of coefficients. I assume it would involve `delta.R`. 

Do you have any insight on this?