### PR TITLE
Fix bootstrap and simulation variance estimation for merMod models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,11 @@ Authors@R: c(person("Thomas J.", "Leeper",
                     role = c("ctb"),
                     email = "jeffrey.arnold@gmail.com"),
              person("Vincent", "Arel-Bundock", 
-                    role = c("ctb"))
+                    role = c("ctb")),
+             person("Jacob A.", "Long", 
+                    role = c("ctb"),
+                    email = "long.1377@osu.edu",
+                    comment = c(ORCID = "0000-0002-1582-6214"))
              )
 URL: https://github.com/leeper/margins
 BugReports: https://github.com/leeper/margins/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Setup a `cplot.default()` method and modified documentation of `cplot()`, `image()`, and `persp()` methods slightly. (#84, h/t Luke Sonnet)
 * Improve the documentation the behavior of `cplot()` for generalized linear models, which can generate unexpected confidence intervals (albeit ones consistent with base R's behavior). (#92)
+* Models fit using the `lme4` package can now have variance estimation via 
+bootstrap and simulation (#105).
 
 # margins 0.3.24
 

--- a/R/get_effect_variances.R
+++ b/R/get_effect_variances.R
@@ -121,9 +121,9 @@ function(data,
         # function to calculate AME for one bootstrap subsample
         bootfun <- function() {
             samp <- sample(seq_len(nrow(data)), nrow(data), TRUE)
-            tmpmodel <- model
-            tmpmodel[["call"]][["data"]] <- data[samp,]
-            tmpmodel <- eval(tmpmodel[["call"]])
+            tmp_call <- getCall(model)
+            tmp_call[["data"]] <- data[samp,]
+            tmpmodel <- eval(tmp_call)
             if (is.null(weights)) {
                 if (is.null(type)) {
                     means <- colMeans(marginal_effects(model = tmpmodel,

--- a/tests/testthat/tests-methods.R
+++ b/tests/testthat/tests-methods.R
@@ -44,6 +44,11 @@ if (requireNamespace("lme4")) {
         expect_true(inherits(margins(m), "margins"))
         expect_true(inherits(margins(m), "margins"))
     })
+    test_that("Test margins(vce = 'bootstrap') for 'lmerMod' (single grouping)", {
+        expect_true(inherits(suppressWarnings({
+            margins(m, vce = "bootstrap", iterations = 5)
+        }), "margins"))  
+    })
     # lmer with multiple random intercepts
     m <- lme4::lmer(weight ~ Diet + (1|Time) + (1|Chick), data = ChickWeight)
     test_that("Test marginal_effects() for 'lmerMod' (multiple grouping)", {
@@ -53,6 +58,11 @@ if (requireNamespace("lme4")) {
     test_that("Test margins() for 'lmerMod' (multiple grouping)", {
         expect_true(inherits(margins(m), "margins"))
         expect_true(inherits(margins(m), "margins"))
+    })
+    test_that("Test margins(vce = 'bootstrap') for 'lmerMod' (multiple grouping)", {
+        expect_true(inherits(suppressWarnings({
+            margins(m, vce = "bootstrap", iterations = 5)
+        }), "margins"))  
     })
     
     # lmer with random slopes
@@ -65,6 +75,11 @@ if (requireNamespace("lme4")) {
         expect_true(inherits(margins(m), "margins"))
         expect_true(inherits(margins(m), "margins"))
     })
+    test_that("Test margins(vce = 'bootstrap') for 'lmerMod' (random slopes)", {
+        expect_true(inherits(suppressWarnings({
+            margins(m, vce = "bootstrap", iterations = 5)
+        }), "margins"))  
+    })
     
     # generalized linear mixed effects models
     ChickWeight$high <- cut(ChickWeight$weight, 2)
@@ -76,6 +91,11 @@ if (requireNamespace("lme4")) {
     test_that("Test margins() for 'merMod'", {
         expect_true(inherits(margins(m), "margins"))
         expect_true(inherits(margins(m), "margins"))
+    })
+    test_that("Test margins(vce = 'bootstrap') for 'merMod'", {
+        expect_true(inherits(suppressWarnings({
+            margins(m, vce = "bootstrap", iterations = 5)
+        }), "margins"))  
     })
     
 }

--- a/tests/testthat/tests-methods.R
+++ b/tests/testthat/tests-methods.R
@@ -44,6 +44,10 @@ if (requireNamespace("lme4")) {
         expect_true(inherits(margins(m), "margins"))
         expect_true(inherits(margins(m), "margins"))
     })
+    test_that("Test margins(vce = 'simulation') for 'lmerMod' (single grouping)", {
+        expect_true(inherits(margins(m, vce = "simulation", iterations = 5),
+                             "margins"))  
+    })
     test_that("Test margins(vce = 'bootstrap') for 'lmerMod' (single grouping)", {
         expect_true(inherits(suppressWarnings({
             margins(m, vce = "bootstrap", iterations = 5)
@@ -58,6 +62,10 @@ if (requireNamespace("lme4")) {
     test_that("Test margins() for 'lmerMod' (multiple grouping)", {
         expect_true(inherits(margins(m), "margins"))
         expect_true(inherits(margins(m), "margins"))
+    })
+    test_that("Test margins(vce = 'simulation') for 'lmerMod' (multiple grouping)", {
+        expect_true(inherits(margins(m, vce = "simulation", iterations = 5),
+                             "margins"))  
     })
     test_that("Test margins(vce = 'bootstrap') for 'lmerMod' (multiple grouping)", {
         expect_true(inherits(suppressWarnings({
@@ -75,6 +83,10 @@ if (requireNamespace("lme4")) {
         expect_true(inherits(margins(m), "margins"))
         expect_true(inherits(margins(m), "margins"))
     })
+    test_that("Test margins(vce = 'simulation') for 'lmerMod' (random slopes)", {
+        expect_true(inherits(margins(m, vce = "simulation", iterations = 5),
+                             "margins"))  
+    })
     test_that("Test margins(vce = 'bootstrap') for 'lmerMod' (random slopes)", {
         expect_true(inherits(suppressWarnings({
             margins(m, vce = "bootstrap", iterations = 5)
@@ -91,6 +103,10 @@ if (requireNamespace("lme4")) {
     test_that("Test margins() for 'merMod'", {
         expect_true(inherits(margins(m), "margins"))
         expect_true(inherits(margins(m), "margins"))
+    })
+    test_that("Test margins(vce = 'simulation') for 'merMod'", {
+        expect_true(inherits(margins(m, vce = "simulation", iterations = 5),
+                             "margins"))  
     })
     test_that("Test margins(vce = 'bootstrap') for 'merMod'", {
         expect_true(inherits(suppressWarnings({


### PR DESCRIPTION
Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/leeper/margins/issues/new) first

This would close #105.

 - [x] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/leeper/margins/blob/master/DESCRIPTION)
 - [x] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/leeper/margins/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [ ] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [x] add code or new test files to [`/tests`](https://github.com/leeper/margins/tree/master/tests/testthat) for any new functionality or bug fix
 - [x] make sure `R CMD check` runs without error before submitting the PR

---

For reference, here was the basic problem: The object manipulation done by `get_effect_variances()` doesn't work on S4 objects like `merMod` models. They aren't subset using `[[`, which is the most proximal cause of the error. These particular objects also have different names for the items the function is looking for. S4 objects also can impose object class restrictions for the internal list items, so things like setting the model frame to `NULL` can't work because `lme4` insists that it be a data frame.

For the bootstrapping code, I was able to use a generalizable fix by just using the call extractor function and manipulating the call rather than the model itself, then evaluating the call and saving that as a temporary model. For the simulation, I had to do some `merMod`-specific control flow (i.e., doing some `if (inherits(model, "merMod")`) which is inelegant but I think better than trying to create an internal S3 method or something like that. 

I should also draw your attention to the fact that for `vce = "simulation"`, we're only simulating the fixed effects and not the random effects. I think this may be okay, and is certainly simpler, but I haven't thought deeply about the statistical theory behind leaving the random effects fixed and simulating only the fixed part of the model.